### PR TITLE
Resolve #15, add /tests mapping to test harness

### DIFF
--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -2,4 +2,5 @@ component skip="true" {
 	this.name = "emit-tests";
 
 	this.mappings["/lib"] = expandPath("../lib");
+	this.mappings["/tests"] = expandPath("./");
 }


### PR DESCRIPTION
Fixes a failing test if run from a subdirectory instead of web root.